### PR TITLE
Improve encoding of null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Table of contents
          * [Overriding Values](#overriding-values)
          * [Validating Values](#validating-values)
          * [Custom Wrapper](#custom-wrapper)
+         * [Encode null values](#encode-null-values)
       * [Contributions](#contributions)
       * [License](#license)
       * [Contact](#contact)
@@ -345,6 +346,49 @@ And voilà
 ```Swift
 struct Test: Kodable {
     @CodingURL("html_url") var url: URL
+}
+```
+
+### Encode Null Values
+
+By default optional values won't be encoded so: 
+
+```Swift
+struct User: Kodable {
+    @Coding var firstName: String
+    @Coding var lastName: String?
+}
+
+let user = User()
+user.firstName = "João"
+```
+
+When encoded will output: 
+
+```Swift
+{
+    "firstName": "João"
+}
+```
+
+However, if you want to explicitly encode null values, then you can set `encodeAsNullIfNil` property to be true: 
+
+```Swift
+struct User: Kodable {
+    @Coding var firstName: String
+    @Coding(encodeAsNullIfNil: true) var lastName: String?
+}
+
+let user = User()
+user.firstName = "João"
+```
+
+Which will then output: 
+
+```Swift
+{
+    "firstName": "João",
+    "lastName": null
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ struct Test: Kodable {
 
 By default optional values won't be encoded so: 
 
-```Swift
+```swift
 struct User: Kodable {
     @Coding var firstName: String
     @Coding var lastName: String?
@@ -365,7 +365,7 @@ user.firstName = "João"
 
 When encoded will output: 
 
-```Swift
+```js
 {
     "firstName": "João"
 }
@@ -373,7 +373,7 @@ When encoded will output:
 
 However, if you want to explicitly encode null values, then you can set `encodeAsNullIfNil` property to be true: 
 
-```Swift
+```swift
 struct User: Kodable {
     @Coding var firstName: String
     @Coding(encodeAsNullIfNil: true) var lastName: String?
@@ -385,7 +385,7 @@ user.firstName = "João"
 
 Which will then output: 
 
-```Swift
+```js
 {
     "firstName": "João",
     "lastName": null

--- a/Sources/Extensions/Optional+Utilities.swift
+++ b/Sources/Extensions/Optional+Utilities.swift
@@ -1,18 +1,5 @@
 import Foundation
 
-// MARK: Verify whether a type is optional
-
-internal protocol OptionalProtocol {
-    var isNil: Bool { get }
-}
-
-extension Optional: OptionalProtocol {
-    var isNil: Bool {
-        guard case .none = self else { return false }
-        return true
-    }
-}
-
 // MARK: Remove double optionals
 
 private protocol Flattenable {
@@ -29,5 +16,18 @@ extension Optional: Flattenable {
         case .none:
             return nil
         }
+    }
+}
+
+// MARK: Verify whether a type is optional
+
+internal protocol OptionalProtocol {
+    var isNil: Bool { get }
+}
+
+extension Optional: OptionalProtocol {
+    var isNil: Bool {
+        guard case .none = flattened() else { return false }
+        return true
     }
 }

--- a/Sources/Extensions/Optional+Utilities.swift
+++ b/Sources/Extensions/Optional+Utilities.swift
@@ -2,9 +2,16 @@ import Foundation
 
 // MARK: Verify whether a type is optional
 
-internal protocol OptionalProtocol {}
+internal protocol OptionalProtocol {
+    var isNil: Bool { get }
+}
 
-extension Optional: OptionalProtocol {}
+extension Optional: OptionalProtocol {
+    var isNil: Bool {
+        guard case .none = self else { return false }
+        return true
+    }
+}
 
 // MARK: Remove double optionals
 

--- a/Sources/Kodable/Codable+AnyCodingKey.swift
+++ b/Sources/Kodable/Codable+AnyCodingKey.swift
@@ -46,8 +46,8 @@ extension DecodeContainer {
 }
 
 extension EncodeContainer {
-    mutating func encodeIfPresent<T>(_ value: T?, with stringKey: String) throws where T: Encodable {
-        try encodeIfPresent(value, forKey: AnyCodingKey(stringKey))
+    mutating func encode<T>(_ value: T, with stringKey: String) throws where T: Encodable {
+        try encode(value, forKey: AnyCodingKey(stringKey))
     }
 
     mutating func nestedContainer(forKey stringKey: String) -> EncodeContainer {

--- a/Sources/Kodable/KodableTransformable.swift
+++ b/Sources/Kodable/KodableTransformable.swift
@@ -163,7 +163,7 @@ extension KodableTransformable: EncodableProperty where OriginalType: Encodable 
     func encodeValueFromProperty(with propertyName: String, to container: inout EncodeContainer) throws {
         var (relevantContainer, relavantKey) = try container.nestedContainerAndKey(for: key ?? propertyName)
         let encodableValue = try transformer.transformToJSON(value: wrappedValue)
-        try relevantContainer.encodeIfPresent(encodableValue, with: relavantKey)
+        try relevantContainer.encode(encodableValue, with: relavantKey)
     }
 }
 

--- a/Sources/Kodable/KodableTransformable.swift
+++ b/Sources/Kodable/KodableTransformable.swift
@@ -20,6 +20,7 @@ public protocol KodableTransform {
     private let modifiers: [KodableModifier<TargetType>]
     public private(set) var key: String?
     public private(set) var decoding: PropertyDecoding = .enforceType
+    public private(set) var encodeAsNullIfNil: Bool = false
 
     public typealias OriginalType = T.From
     public typealias TargetType = T.To
@@ -38,10 +39,11 @@ public protocol KodableTransform {
         set { _value = newValue }
     }
 
-    internal init(key: String? = nil, decoding: PropertyDecoding, modifiers: [KodableModifier<TargetType>], defaultValue: TargetType?) {
+    internal init(key: String? = nil, decoding: PropertyDecoding, encodeAsNullIfNil: Bool, modifiers: [KodableModifier<TargetType>], defaultValue: TargetType?) {
         self.key = key
         self.modifiers = modifiers
         self.decoding = decoding
+        self.encodeAsNullIfNil = encodeAsNullIfNil
         _value = defaultValue
     }
 
@@ -163,6 +165,8 @@ extension KodableTransformable: EncodableProperty where OriginalType: Encodable 
     func encodeValueFromProperty(with propertyName: String, to container: inout EncodeContainer) throws {
         var (relevantContainer, relavantKey) = try container.nestedContainerAndKey(for: key ?? propertyName)
         let encodableValue = try transformer.transformToJSON(value: wrappedValue)
+        let isValueNil = (encodableValue as? OptionalProtocol)?.isNil ?? false
+        guard !isValueNil || encodeAsNullIfNil else { return }
         try relevantContainer.encode(encodableValue, with: relavantKey)
     }
 }

--- a/Sources/Wrappers/CodableDate.swift
+++ b/Sources/Wrappers/CodableDate.swift
@@ -115,3 +115,11 @@ public enum DateCodingStrategy {
         return dateFormatter
     }
 }
+
+// MARK: Equatable Conformance
+
+extension CodableDate: Equatable where T: Equatable {
+    public static func == (lhs: CodableDate<T>, rhs: CodableDate<T>) -> Bool {
+        lhs.wrappedValue == rhs.wrappedValue
+    }
+}

--- a/Sources/Wrappers/CodableDate.swift
+++ b/Sources/Wrappers/CodableDate.swift
@@ -18,16 +18,16 @@ import Foundation
         super.init()
     }
 
-    public init(decoding: PropertyDecoding = .enforceType, _ modifiers: KodableModifier<T>..., default value: T? = nil) {
-        super.init(key: nil, decoding: decoding, modifiers: modifiers, defaultValue: value)
+    public init(decoding: PropertyDecoding = .enforceType, encodeAsNullIfNil: Bool = false, _ modifiers: KodableModifier<T>..., default value: T? = nil) {
+        super.init(key: nil, decoding: decoding, encodeAsNullIfNil: encodeAsNullIfNil, modifiers: modifiers, defaultValue: value)
     }
 
-    public init(_ key: String, decoding: PropertyDecoding = .enforceType, _ modifiers: KodableModifier<T>..., default value: T? = nil) {
-        super.init(key: key, decoding: decoding, modifiers: modifiers, defaultValue: value)
+    public init(_ key: String, decoding: PropertyDecoding = .enforceType, encodeAsNullIfNil: Bool = false, _ modifiers: KodableModifier<T>..., default value: T? = nil) {
+        super.init(key: key, decoding: decoding, encodeAsNullIfNil: encodeAsNullIfNil, modifiers: modifiers, defaultValue: value)
     }
 
-    public init(_ strategy: DateCodingStrategy, _ key: String? = nil, decoding: PropertyDecoding = .enforceType, _ modifiers: KodableModifier<T>..., default value: T? = nil) {
-        super.init(key: key, decoding: decoding, modifiers: modifiers, defaultValue: value)
+    public init(_ strategy: DateCodingStrategy, _ key: String? = nil, decoding: PropertyDecoding = .enforceType, encodeAsNullIfNil: Bool = false, _ modifiers: KodableModifier<T>..., default value: T? = nil) {
+        super.init(key: key, decoding: decoding, encodeAsNullIfNil: encodeAsNullIfNil, modifiers: modifiers, defaultValue: value)
         transformer.strategy = strategy
     }
 

--- a/Sources/Wrappers/Coding.swift
+++ b/Sources/Wrappers/Coding.swift
@@ -12,15 +12,15 @@ import Foundation
 
     /// - Parameters:
     ///   - decoding: Changes the decoding method used. Defaults to `decoding(.enforceType)`.
-    public convenience init(decoding: PropertyDecoding = .enforceType, _ modifiers: KodableModifier<TargetType>..., default value: TargetType? = nil) {
-        self.init(key: nil, decoding: decoding, modifiers: modifiers, defaultValue: value)
+    public convenience init(decoding: PropertyDecoding = .enforceType, encodeAsNullIfNil: Bool = false, _ modifiers: KodableModifier<TargetType>..., default value: TargetType? = nil) {
+        self.init(key: nil, decoding: decoding, encodeAsNullIfNil: encodeAsNullIfNil, modifiers: modifiers, defaultValue: value)
     }
 
     /// - Parameters:
     ///   - key: Customize the string key used to decode the value. Nested values are supported through the usage of the `.` notation.
     ///   - decoding: Changes the decoding method used. Defaults to `decoding(.enforceType)`.
-    public convenience init(_ key: String, decoding: PropertyDecoding = .enforceType, _ modifiers: KodableModifier<TargetType>..., default value: TargetType? = nil) {
-        self.init(key: key, decoding: decoding, modifiers: modifiers, defaultValue: value)
+    public convenience init(_ key: String, decoding: PropertyDecoding = .enforceType, encodeAsNullIfNil: Bool = false, _ modifiers: KodableModifier<TargetType>..., default value: TargetType? = nil) {
+        self.init(key: key, decoding: decoding, encodeAsNullIfNil: encodeAsNullIfNil, modifiers: modifiers, defaultValue: value)
     }
 }
 

--- a/Sources/Wrappers/Coding.swift
+++ b/Sources/Wrappers/Coding.swift
@@ -33,3 +33,11 @@ public struct Passthrough<T: Codable>: KodableTransform {
     public func transformToJSON(value: T) -> T { value }
     public init() {}
 }
+
+// MARK: Equatable Conformance
+
+extension Coding: Equatable where T: Equatable {
+    public static func == (lhs: Coding<T>, rhs: Coding<T>) -> Bool {
+        lhs.wrappedValue == rhs.wrappedValue
+    }
+}

--- a/Tests/KodableTests.swift
+++ b/Tests/KodableTests.swift
@@ -554,7 +554,30 @@ final class KodableTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    
+    // MARK: - Equatable
 
+    func testCodableConformsToEquatable() {
+        struct User: Kodable, Equatable {
+            @Coding var name: String
+            
+            static func with(name: String) -> User {
+                let user = User()
+                user.name = name
+                return user
+            }
+        }
+
+        let a = User.with(name: "João")
+        let b = User.with(name: "Roger")
+        let c = a
+        
+        XCTAssertNotEqual(a.name, b.name)
+        XCTAssertNotEqual(a, b)
+        XCTAssertEqual(a.name, c.name)
+        XCTAssertEqual(a, c)
+    }
+    
     // MARK: - CodableDate
 
     func testDateTransformerFailedToParseError() {
@@ -635,6 +658,33 @@ final class KodableTests: XCTestCase {
             @CodableDate("social") var isoDate: Date
         }
         assert(try Dates.decodeJSON(from: KodableTests.json), throws: KodableError.failedToParseDate(source: "123456789987654321"))
+    }
+    
+    // MARK: - Equatable
+
+    func testCodableDateConformsToEquatable() throws {
+        struct RFCDate: Kodable, Equatable {
+            @CodableDate(.rfc2822, "rfc2822") var date: Date
+            
+            static func fromJSON() throws -> RFCDate {
+                try RFCDate.decodeJSON(from: KodableTests.json)
+            }
+            
+            static func now() -> RFCDate {
+                let now = RFCDate()
+                now.date = Date()
+                return now
+            }
+        }
+
+        let a = try RFCDate.fromJSON()
+        let b = RFCDate.now()
+        let c = a
+        
+        XCTAssertNotEqual(a.date, b.date)
+        XCTAssertNotEqual(a, b)
+        XCTAssertEqual(a.date, c.date)
+        XCTAssertEqual(a, c)
     }
 
     // MARK: - Flattened Tests

--- a/Tests/KodableTests.swift
+++ b/Tests/KodableTests.swift
@@ -45,6 +45,19 @@ final class KodableTests: XCTestCase {
         }
     }
 
+    func testEncodingNullValuesOutput() throws {
+        struct Strings: Kodable {
+            @Coding var optionalString: String?
+            @Coding(encodeAsNullIfNil: true) var nullOptionalString: String?
+        }
+
+        let strings = Strings()
+        let data = try strings.encodeJSON()
+        let dic = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+        XCTAssertNil(dic!["optionalString"])
+        XCTAssertEqual(dic!["nullOptionalString"] as? NSNull, NSNull())
+    }
+
     func testEncodingAndDecodingUsingCoder() {
         struct User: Kodable {
             @Coding("first_name") var firstName: String
@@ -554,13 +567,13 @@ final class KodableTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
-    
+
     // MARK: - Equatable
 
     func testCodableConformsToEquatable() {
         struct User: Kodable, Equatable {
             @Coding var name: String
-            
+
             static func with(name: String) -> User {
                 let user = User()
                 user.name = name
@@ -571,13 +584,13 @@ final class KodableTests: XCTestCase {
         let a = User.with(name: "João")
         let b = User.with(name: "Roger")
         let c = a
-        
+
         XCTAssertNotEqual(a.name, b.name)
         XCTAssertNotEqual(a, b)
         XCTAssertEqual(a.name, c.name)
         XCTAssertEqual(a, c)
     }
-    
+
     // MARK: - CodableDate
 
     func testDateTransformerFailedToParseError() {
@@ -659,17 +672,17 @@ final class KodableTests: XCTestCase {
         }
         assert(try Dates.decodeJSON(from: KodableTests.json), throws: KodableError.failedToParseDate(source: "123456789987654321"))
     }
-    
+
     // MARK: - Equatable
 
     func testCodableDateConformsToEquatable() throws {
         struct RFCDate: Kodable, Equatable {
             @CodableDate(.rfc2822, "rfc2822") var date: Date
-            
+
             static func fromJSON() throws -> RFCDate {
                 try RFCDate.decodeJSON(from: KodableTests.json)
             }
-            
+
             static func now() -> RFCDate {
                 let now = RFCDate()
                 now.date = Date()
@@ -680,11 +693,21 @@ final class KodableTests: XCTestCase {
         let a = try RFCDate.fromJSON()
         let b = RFCDate.now()
         let c = a
-        
+
         XCTAssertNotEqual(a.date, b.date)
         XCTAssertNotEqual(a, b)
         XCTAssertEqual(a.date, c.date)
         XCTAssertEqual(a, c)
+    }
+
+    // MARK: - OptionalProtocol Tests
+
+    func testOptionalProtocolIsNil() {
+        let nonNilValue: String? = ""
+        let nilValue: String? = nil
+
+        XCTAssertFalse(nonNilValue.isNil)
+        XCTAssertTrue(nilValue.isNil)
     }
 
     // MARK: - Flattened Tests

--- a/Tests/KodableTests.swift
+++ b/Tests/KodableTests.swift
@@ -54,7 +54,7 @@ final class KodableTests: XCTestCase {
         let strings = Strings()
         let data = try strings.encodeJSON()
         let dic = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
-        XCTAssertNil(dic!["optionalString"])
+        XCTAssertFalse(dic!.keys.contains("optionalString"))
         XCTAssertEqual(dic!["nullOptionalString"] as? NSNull, NSNull())
     }
 
@@ -700,16 +700,6 @@ final class KodableTests: XCTestCase {
         XCTAssertEqual(a, c)
     }
 
-    // MARK: - OptionalProtocol Tests
-
-    func testOptionalProtocolIsNil() {
-        let nonNilValue: String? = ""
-        let nilValue: String? = nil
-
-        XCTAssertFalse(nonNilValue.isNil)
-        XCTAssertTrue(nilValue.isNil)
-    }
-
     // MARK: - Flattened Tests
 
     // https://gist.github.com/rogerluan/ee04febd80371f88f9435e98032b3042
@@ -733,6 +723,22 @@ final class KodableTests: XCTestCase {
         XCTAssert(isEqual(type: Int?.self, a: Int???????.none.flattened(), b: nil))
         let _20levelsNested: Int???????????????????? = 20
         XCTAssert(isEqual(type: Int?.self, a: _20levelsNested.flattened(), b: Optional(20)))
+    }
+
+    // MARK: - OptionalProtocol Tests
+
+    func testOptionalProtocolIsNil() {
+        let nonNilValue: String? = ""
+        let doubleNonNilValue: String?? = ""
+        let nilValue: String? = nil
+        let doubleNilValue: String?? = nil
+        let optionalEnum: String?? = .some(nil)
+
+        XCTAssertFalse(nonNilValue.isNil)
+        XCTAssertFalse(doubleNonNilValue.isNil)
+        XCTAssertTrue(nilValue.isNil)
+        XCTAssertTrue(doubleNilValue.isNil)
+        XCTAssertTrue(optionalEnum.isNil)
     }
 
     // MARK: - Utilities


### PR DESCRIPTION
Fixes the default behaviour, where nil values were encoded as `null`. Now it skips nil values, following default `Codable` behaviour. 

It adds an option to force nil values to be encoded as `null` by doing 

```
@Coding(encodeAsNullIfNil: true) var lastName: String?
```

Resolves #6 