### PR TITLE
Fix NSNumber to Bool Lossless Decoding

### DIFF
--- a/Tests/KodableTests.swift
+++ b/Tests/KodableTests.swift
@@ -481,7 +481,7 @@ final class KodableTests: XCTestCase {
             XCTAssertEqual(lossless.array, ["1", "1.5", "2", "true", "3", "4"])
 
             let lossy = try LossyArray.decodeJSON(from: KodableTests.json)
-            XCTAssertEqual(lossy.array[0].name, "3")
+            XCTAssertEqual(lossy.array[0].name, "1")
             XCTAssertEqual(lossy.array[1].name, "john")
         } catch {
             XCTFail(error.localizedDescription)
@@ -839,7 +839,7 @@ final class KodableTests: XCTestCase {
         "two": [1, 2, 3, 4],
         "three": "Invalid Value",
         "failable_array": ["1", 1.5, "2", true, "3", nil, 4],
-        "failable_lossy_array": [["name": 3], ["dragonite": "this key will fail to be parsed"], ["name": "john"]],
+        "failable_lossy_array": [["name": 1], ["dragonite": "this key will fail to be parsed"], ["name": "john"]],
         "age": "18",
         "cm_height": "170",
         "children_count": "invalid",


### PR DESCRIPTION
Previously, if we tried to decode a JSON containing a NSNumber that is convertible to Bool (0 or 1) to String, this would be the result:

```
{ "failable_string": 1 }

@Coding("failable_string", decoding: .lossless) var string: String

Output: "true"
```

Expected:
The `LosslessValue` decoder only tries to decode the NSNumber to Bool it this was our target type.

Actual result:
The `LosslessValue` decoder always tries to decode the NSNumber to Bool before converting it to String.