### PR TITLE
Add Makefile to Help Lint the Project Locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+lint:
+	swiftformat .
+	swiftlint --fix


### PR DESCRIPTION
## Description

Usage:

```sh
make
```

or, alternatively (when there are other tasks in the Makefile in the future):

```sh
make lint
```

## Precondition

You need to have swiftformat and swiftlint installed on your local machine and accessible via your `$PATH`, since this project doesn't maintain its own version of linters.

## Demo

<img width="513" alt="image" src="https://user-images.githubusercontent.com/8419048/156409999-b301f8a3-d8d2-4453-84a6-228dc7e80252.png">
