### PR TITLE
Refactor `KodableTransformable` and wrappers to be structs instead of classes

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,2 @@
 brew "swiftformat"
+brew "swiftlint"

--- a/Sources/Extensions/Optional+Utilities.swift
+++ b/Sources/Extensions/Optional+Utilities.swift
@@ -21,7 +21,7 @@ extension Optional: Flattenable {
 
 // MARK: Verify whether a type is optional
 
-internal protocol OptionalProtocol {
+protocol OptionalProtocol {
     var isNil: Bool { get }
 }
 

--- a/Sources/Extensions/TryCatch+Utilities.swift
+++ b/Sources/Extensions/TryCatch+Utilities.swift
@@ -19,7 +19,7 @@ extension FailableExpressionWithFallbackError: LocalizedError {
     }
 }
 
-internal func failableExpression<T>(_ expression: @autoclosure () throws -> T, withFallback fallback: @autoclosure () throws -> T) throws -> T {
+func failableExpression<T>(_ expression: @autoclosure () throws -> T, withFallback fallback: @autoclosure () throws -> T) throws -> T {
     do {
         return try expression()
     } catch let firstError {

--- a/Sources/Kodable/Codable+Lossless.swift
+++ b/Sources/Kodable/Codable+Lossless.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - LosslessDecodable
 
-public typealias LosslessDecodable = LosslessStringConvertible & Decodable
+public typealias LosslessDecodable = Decodable & LosslessStringConvertible
 
 // MARK: Helper types to decode lossless values
 
@@ -43,7 +43,7 @@ struct LosslessDecodableArray<Element: Decodable>: Decodable {
     }
 }
 
-internal struct Corrupted: Error {}
+struct Corrupted: Error {}
 
 // MARK: Helper type to decode lossy arrays
 

--- a/Sources/Kodable/KodableError.swift
+++ b/Sources/Kodable/KodableError.swift
@@ -22,13 +22,13 @@ extension KodableError: CustomStringConvertible {
         stringErrorTree(for: self)
     }
 
-    internal func stringErrorTree(for error: KodableError?, initial: String = "", tabs: Int = 0) -> String {
+    func stringErrorTree(for error: KodableError?, initial: String = "", tabs: Int = 0) -> String {
         if error == nil { return initial }
         let message = initial + String(repeating: "   ", count: tabs) + "\(error?.errorDescription ?? "")\n"
         return stringErrorTree(for: error?.nextWrapper, initial: message, tabs: tabs + 1)
     }
 
-    internal var nextWrapper: KodableError? {
+    var nextWrapper: KodableError? {
         switch self {
         case let .failedDecodingProperty(_, _, _, underlyingError):
             return underlyingError
@@ -42,7 +42,7 @@ extension KodableError: CustomStringConvertible {
         }
     }
 
-    internal var hasKodableErrorChildrenErrors: Bool {
+    var hasKodableErrorChildrenErrors: Bool {
         switch nextWrapper {
         case nil: return false
         case let .wrappedError(error):
@@ -52,7 +52,7 @@ extension KodableError: CustomStringConvertible {
         }
     }
 
-    internal var errorDescription: String {
+    var errorDescription: String {
         switch self {
         case let .wrappedError(error):
             return hasKodableErrorChildrenErrors ? "" : "Cause: \(BetterDecodingError(with: error).description)"

--- a/Sources/Kodable/KodableOption.swift
+++ b/Sources/Kodable/KodableOption.swift
@@ -41,8 +41,8 @@ public struct KodableModifier<T> {
         validation = { _ in true }
     }
 
-    internal func validate(_ value: T) -> Bool { validation(value) }
-    internal func overrideValue(_ value: T) -> T { overrideValue(value) }
+    func validate(_ value: T) -> Bool { validation(value) }
+    func overrideValue(_ value: T) -> T { overrideValue(value) }
 }
 
 // MARK: - Helpers

--- a/Sources/Kodable/KodableTransformable.swift
+++ b/Sources/Kodable/KodableTransformable.swift
@@ -15,8 +15,8 @@ public protocol KodableTransform {
 // MARK: Kodable Transformable Property Wrapper
 
 @propertyWrapper public struct KodableTransformable<T: KodableTransform>: Codable {
-    internal var transformer = T()
-    internal var _value: T.To?
+    var transformer = T()
+    var _value: T.To?
     private let options: [KodableOption<TargetType>]
     public private(set) var key: String?
 
@@ -45,7 +45,7 @@ public protocol KodableTransform {
     ///         and it can't be decoded, and a default value wasn't provided.
     public var wrappedValue: TargetType {
         get {
-            return getValue(TargetType.self)
+            getValue(TargetType.self)
         }
         mutating set {
             try? setValue(newValue)
@@ -55,9 +55,9 @@ public protocol KodableTransform {
     // MARK: Public Initializers
 
     public init(wrappedValue: TargetType) {
-        self.key = nil
-        self.options = []
-        self._value = wrappedValue
+        key = nil
+        options = []
+        _value = wrappedValue
     }
 
     public init() {
@@ -91,7 +91,9 @@ public protocol KodableTransform {
 extension KodableTransformable {
     private func overrideRawValueIfNeeded(_ value: TargetType) -> TargetType {
         var modifiedCopy = value
-        for modifier in modifiers { modifiedCopy = modifier.overrideValue(modifiedCopy) }
+        for modifier in modifiers {
+            modifiedCopy = modifier.overrideValue(modifiedCopy)
+        }
         return modifiedCopy
     }
 

--- a/Sources/Wrappers/CodableDate.swift
+++ b/Sources/Wrappers/CodableDate.swift
@@ -17,24 +17,24 @@ import Foundation
     public var projectedValue: Self { self }
 
     public init() {
-        self.inner = KodableTransformable()
+        inner = KodableTransformable()
     }
 
     public init(_ options: KodableOption<T>..., default value: T? = nil) {
-        self.inner = KodableTransformable(options: options, defaultValue: value)
+        inner = KodableTransformable(options: options, defaultValue: value)
     }
 
     public init(_ key: String, _ options: KodableOption<T>..., default value: T? = nil) {
-        self.inner = KodableTransformable(key: key, options: options, defaultValue: value)
+        inner = KodableTransformable(key: key, options: options, defaultValue: value)
     }
 
     public init(_ strategy: DateCodingStrategy, _ key: String? = nil, _ options: KodableOption<T>..., default value: T? = nil) {
-        self.inner = KodableTransformable(key: key, options: options, defaultValue: value)
+        inner = KodableTransformable(key: key, options: options, defaultValue: value)
         inner.transformer.strategy = strategy
     }
 
     public init(from decoder: Decoder) throws {
-        self.inner = try KodableTransformable(from: decoder)
+        inner = try KodableTransformable(from: decoder)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -45,7 +45,7 @@ import Foundation
 // MARK: Conforming to CodableTransform
 
 public struct DateTransformer<T: DateProtocol>: KodableTransform {
-    internal var strategy: DateCodingStrategy = .iso8601
+    var strategy: DateCodingStrategy = .iso8601
 
     public func transformFromJSON(value: String?) throws -> T {
         let dateValue = strategy.date(from: value ?? "")

--- a/Sources/Wrappers/Coding.swift
+++ b/Sources/Wrappers/Coding.swift
@@ -13,19 +13,19 @@ import Foundation
     }
 
     public init() {
-        self.inner = KodableTransformable()
+        inner = KodableTransformable()
     }
 
     public init(_ options: KodableOption<T>..., default value: T? = nil) {
-        self.inner = KodableTransformable(options: options, defaultValue: value)
+        inner = KodableTransformable(options: options, defaultValue: value)
     }
 
     public init(_ key: String, _ options: KodableOption<T>..., default value: T? = nil) {
-        self.inner = KodableTransformable(key: key, options: options, defaultValue: value)
+        inner = KodableTransformable(key: key, options: options, defaultValue: value)
     }
 
     public init(from decoder: Decoder) throws {
-        self.inner = try KodableTransformable(from: decoder)
+        inner = try KodableTransformable(from: decoder)
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Tests/KodableTests.swift
+++ b/Tests/KodableTests.swift
@@ -107,7 +107,7 @@ final class KodableTests: XCTestCase {
 
         let failedProperty = KodableError.failedDecodingProperty(property: "phone", key: "phone", type: String.self, underlyingError: .dataNotFound)
         let error = KodableError.failedDecodingType(type: FailingUser.self, underlyingError: failedProperty)
-        assert(try FailingUser.decodeJSON(from: KodableTests.json), throws: error)
+        try assert(FailingUser.decodeJSON(from: KodableTests.json), throws: error)
     }
 
     func testNestedKeys() {
@@ -219,7 +219,7 @@ final class KodableTests: XCTestCase {
         let validationFailed = KodableError.validationFailed(type: Int.self, property: "width", parsedValue: 400)
         let thrownError = KodableError.failedDecodingType(type: Failed.self, underlyingError: validationFailed)
 
-        assert(try Failed.decodeJSON(from: data), throws: thrownError)
+        try assert(Failed.decodeJSON(from: data), throws: thrownError)
     }
 
     func testModifierAndValidationOnAssignment() {
@@ -266,7 +266,7 @@ final class KodableTests: XCTestCase {
         let failedProperty = KodableError.failedDecodingProperty(property: "notBool", key: "string_bool", type: Bool.self, underlyingError: .wrappedError(typeMismatch))
         let thrownError = KodableError.failedDecodingType(type: Failed.self, underlyingError: failedProperty)
 
-        assert(try Failed.decodeJSON(from: data), throws: thrownError)
+        try assert(Failed.decodeJSON(from: data), throws: thrownError)
     }
 
     func testMissingProperty() {
@@ -278,12 +278,12 @@ final class KodableTests: XCTestCase {
         let failedProperty = KodableError.failedDecodingProperty(property: "size", key: "size", type: Int.self, underlyingError: .dataNotFound)
         let thrownError = KodableError.failedDecodingType(type: Failed.self, underlyingError: failedProperty)
 
-        assert(try Failed.decodeJSON(from: data), throws: thrownError)
+        try assert(Failed.decodeJSON(from: data), throws: thrownError)
     }
 
     func testInvalidDataForProperty() {
         struct NonOptionalDateTransformer: KodableTransform {
-            internal var strategy: DateCodingStrategy = .iso8601
+            var strategy: DateCodingStrategy = .iso8601
 
             public func transformFromJSON(value: String) throws -> Date {
                 let dateValue = strategy.date(from: value)
@@ -308,7 +308,7 @@ final class KodableTests: XCTestCase {
         let failedProperty = KodableError.failedDecodingProperty(property: "animated", key: "animated", type: Int.self, underlyingError: .wrappedError(typeMismatch))
         let thrownError = KodableError.failedDecodingType(type: Failed.self, underlyingError: failedProperty)
 
-        assert(try Failed.decodeJSON(from: data), throws: thrownError)
+        try assert(Failed.decodeJSON(from: data), throws: thrownError)
     }
 
     func testInheritance() {
@@ -449,7 +449,7 @@ final class KodableTests: XCTestCase {
         let failedStringProperty = KodableError.failedDecodingProperty(property: "string", key: "languages", type: String.self, underlyingError: .wrappedError(failedStringFallback))
         let failedStringThrownError = KodableError.failedDecodingType(type: FailingString.self, underlyingError: failedStringProperty)
 
-        assert(try FailingString.decodeJSON(from: KodableTests.json), throws: failedStringThrownError)
+        try assert(FailingString.decodeJSON(from: KodableTests.json), throws: failedStringThrownError)
 
         // Missing String
         let missingContext = DecodingError.Context(codingPath: [], debugDescription: "No value associated with key AnyCodingKey(stringValue: \"missing_languages\", intValue: nil) (\"missing_languages\").", underlyingError: nil)
@@ -458,7 +458,7 @@ final class KodableTests: XCTestCase {
         let missingStringProperty = KodableError.failedDecodingProperty(property: "string", key: "missing_languages", type: String.self, underlyingError: .wrappedError(missingStringFallback))
         let missingStringThrownError = KodableError.failedDecodingType(type: MissingString.self, underlyingError: missingStringProperty)
 
-        assert(try MissingString.decodeJSON(from: KodableTests.json), throws: missingStringThrownError)
+        try assert(MissingString.decodeJSON(from: KodableTests.json), throws: missingStringThrownError)
     }
 
     func testOptionalLosslessDecodableConformance() {
@@ -575,17 +575,17 @@ final class KodableTests: XCTestCase {
         let typeMismatch = DecodingError.typeMismatch(Int.self, enforcedContext)
         let enforcedFailedProperty = KodableError.failedDecodingProperty(property: "array", key: "failable_array", type: [String].self, underlyingError: .wrappedError(typeMismatch))
         let enforcedTypeThrownError = KodableError.failedDecodingType(type: EnforcedTypeArray.self, underlyingError: enforcedFailedProperty)
-        assert(try EnforcedTypeArray.decodeJSON(from: KodableTests.json), throws: enforcedTypeThrownError)
+        try assert(EnforcedTypeArray.decodeJSON(from: KodableTests.json), throws: enforcedTypeThrownError)
 
         let invalidFailedProperty = KodableError.failedDecodingProperty(property: "array", key: "failable_lossy_array", type: [LossyStruct].self, underlyingError: .wrappedError(Corrupted()))
         let invalidLosslessArrayThrownError = KodableError.failedDecodingType(type: InvalidLosslessArray.self, underlyingError: invalidFailedProperty)
-        assert(try InvalidLosslessArray.decodeJSON(from: KodableTests.json), throws: invalidLosslessArrayThrownError)
+        try assert(InvalidLosslessArray.decodeJSON(from: KodableTests.json), throws: invalidLosslessArrayThrownError)
 
         let missingContext = DecodingError.Context(codingPath: [], debugDescription: "", underlyingError: nil)
         let keyNotFound = DecodingError.keyNotFound(AnyCodingKey(stringValue: "missing_array")!, missingContext)
         let missingFailedProperty = KodableError.failedDecodingProperty(property: "array", key: "missing_array", type: [String].self, underlyingError: .wrappedError(keyNotFound))
         let missingArrayThrownError = KodableError.failedDecodingType(type: MissingArray.self, underlyingError: missingFailedProperty)
-        assert(try MissingArray.decodeJSON(from: KodableTests.json), throws: missingArrayThrownError)
+        try assert(MissingArray.decodeJSON(from: KodableTests.json), throws: missingArrayThrownError)
     }
 
     // MARK: - Mix And Match With Codable Tests
@@ -703,7 +703,7 @@ final class KodableTests: XCTestCase {
         let transformer = DateTransformer<Date>()
         let optionalTransformer = DateTransformer<Date?>()
 
-        assert(try transformer.transformFromJSON(value: nil), throws: KodableError.failedToParseDate(source: "nil"))
+        try assert(transformer.transformFromJSON(value: nil), throws: KodableError.failedToParseDate(source: "nil"))
         XCTAssertEqual(try optionalTransformer.transformFromJSON(value: nil), nil)
     }
 
@@ -806,7 +806,7 @@ final class KodableTests: XCTestCase {
 
         let cannotDecodeDate = KodableError.failedToParseDate(source: "123456789987654321")
         let thrownError = KodableError.failedDecodingType(type: Dates.self, underlyingError: cannotDecodeDate)
-        assert(try Dates.decodeJSON(from: KodableTests.json), throws: thrownError)
+        try assert(Dates.decodeJSON(from: KodableTests.json), throws: thrownError)
     }
 
     // MARK: - Equatable
@@ -892,7 +892,7 @@ final class KodableTests: XCTestCase {
         XCTAssertEqual(success, 1)
         let firstErrorButResult = try failableExpression(firstError(), withFallback: successExpresion())
         XCTAssertEqual(firstErrorButResult, 1)
-        assert(try failableExpression(firstError(), withFallback: secondError()), throws: FailableExpressionWithFallbackError(main: FirstError(), fallback: SecondError()))
+        try assert(failableExpression(firstError(), withFallback: secondError()), throws: FailableExpressionWithFallbackError(main: FirstError(), fallback: SecondError()))
     }
 
     func testBetterDecodingError() {
@@ -1016,7 +1016,6 @@ final class KodableTests: XCTestCase {
 
         XCTAssertEqual(value, 42)
     }
-
 
     // MARK: - Utilities
 


### PR DESCRIPTION
## Summary

This PR refactors `KodableTransformable`, `Coding` and `CodableDate` to use `struct` instead of `class`, aligning with Swift's value semantics and best practices.

Fixes #23

## Motivations

- **Safer Memory Model**: Avoid unintended shared mutable state, reducing the risk of race conditions and side effects.
- **Improved Concurrency**: Value types are inherently safer in multithreaded contexts, aligning with Swift's move toward data isolation.
- **Predictable Behavior**: Makes ownership and mutation flow explicit, leading to easier reasoning about the API and more reliable testing.

## Follow-up

This is a breaking change and should be released as a major version update.