### PR TITLE
Fix thread-safety bug in Reflection.typeInformation() causing crashes

### DIFF
--- a/Sources/Extensions/Runtime+Utilities.swift
+++ b/Sources/Extensions/Runtime+Utilities.swift
@@ -1,13 +1,22 @@
+import Foundation
 import Runtime
 
 public enum Reflection {
     /// Returns information for a given type, such as its properties and its type
     public static func typeInformation(of type: Any.Type) throws -> TypeInfo {
-        // Try fetching from the cache first
         let hashedType = HashedType(type)
-        if let cached = cachedTypeInfo[hashedType] { return cached }
-        // Compute Type Info when needed
+
+        // Thread-safe read from cache
+        cacheLock.lock()
+        if let cached = cachedTypeInfo[hashedType] {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        // Compute Type Info outside the lock
         var newTypeInfo = try typeInfo(of: type)
+
         // As of version Runtime 2.2.2, when there are multiple super classes, properties are duplicated
         var propertyNames: Set<String> = []
         newTypeInfo.properties = newTypeInfo.properties.filter { p in
@@ -15,13 +24,18 @@ public enum Reflection {
             propertyNames.insert(p.name)
             return true
         }
+
+        // Thread-safe write to cache
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+
+        if let cached = cachedTypeInfo[hashedType] { return cached }
         cachedTypeInfo[hashedType] = newTypeInfo
         return newTypeInfo
     }
 }
 
 extension Reflection {
-    // Caching for performance
     private struct HashedType: Hashable {
         private var hashKey: Int
         init(_ type: Any.Type) { hashKey = unsafeBitCast(type, to: Int.self) }
@@ -29,5 +43,6 @@ extension Reflection {
         static func == (lhs: HashedType, rhs: HashedType) -> Bool { lhs.hashValue == rhs.hashValue }
     }
 
+    private static let cacheLock = NSLock()
     private static var cachedTypeInfo: [HashedType: TypeInfo] = [:]
 }

--- a/Tests/KodableTests.swift
+++ b/Tests/KodableTests.swift
@@ -475,7 +475,7 @@ final class KodableTests: XCTestCase {
         let dispatchGroup = DispatchGroup()
         let types: [Any.Type] = [String.self, Int.self, Double.self, Bool.self, Data.self]
 
-        for _ in 0..<iterations {
+        for _ in 0 ..< iterations {
             for type in types {
                 dispatchGroup.enter()
                 DispatchQueue.global().async {


### PR DESCRIPTION
## Description

### Problem
The `cachedTypeInfo` dictionary in `Reflection.typeInformation()` is accessed concurrently without synchronization, causing `EXC_BAD_ACCESS` crashes in production when performing concurrent JSON decoding.

**Crash signature:**
```
  EXC_BAD_ACCESS (Code 1, Subcode 9223372036854775824)
  KERN_INVALID_ADDRESS at 0x8000000000000010
  Dictionary.subscript.getter (compiler-generated)
```

**Root Cause**
Swift's Dictionary is not thread-safe. When multiple threads decode JSON concurrently (common in apps making parallel API calls), each thread calls `Reflection.typeInformation()`, causing concurrent *read/write* operations on the shared cachedTypeInfo dictionary.

### Solution
Added `NSLock` synchronization with a double-check pattern to ensure thread-safe access while minimizing lock contention.

### Why This Approach
- `NSLock` - Lightweight, appropriate for short critical sections
- Unlock before computation - The `typeInfo(of:)` call is expensive; keeping it outside the lock minimizes contention
- Double-check pattern - Prevents redundant computation if another thread populated the cache while we were working
- `defer` for unlock - Ensures lock release even if an error occurs